### PR TITLE
#165305275 Pagination support for articles

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -81,11 +81,21 @@ class ArticleView(viewsets.ModelViewSet):
     def list(self, request):
         """
         get:
-        The get article endpoint
+        The get articles endpoint
         """
+        page_limit = request.GET.get('limit')
+
+        if not page_limit or not page_limit.isdigit():
+            page_limit = 9
+
         queryset = self.queryset
-        serializer = ArticleSerializer(queryset, many=True,
+        paginator = PageNumberPagination()
+        paginator.page_size = page_limit
+
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = ArticleSerializer(page, many=True,
                                        context={'request': request})
+
         dictionary = None
         data = []
         for article in serializer.data:
@@ -93,9 +103,7 @@ class ArticleView(viewsets.ModelViewSet):
             dictionary['author'] = user_object(dictionary['author'])
             data.append(dictionary)
 
-        return JsonResponse({"status": 200,
-                             "data": data},
-                            status=200)
+        return paginator.get_paginated_response(data=data)
 
     def retrieve(self, request, slug=None):
         """

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -166,6 +166,10 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'authors.apps.profiles.permissions.IsGetOrIsAuthenticated',
     ),
+    'DEFAULT_PAGINATION_CLASS':
+    'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE':
+    env.int('DJANGO_DEFAULT_PAGE_SIZE', default=25),
 }
 
 # jwt authentication settings

--- a/authors/tests/data/test_articles.py
+++ b/authors/tests/data/test_articles.py
@@ -10,6 +10,9 @@ from ...apps.articles.models import ArticleModel
 from ...apps.articles.views import ArticleView
 import json
 import os
+import random
+import string
+
 from PIL import Image
 
 
@@ -182,6 +185,36 @@ class ModelTestCase(BaseTest):
 
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
+
+    def test_can_get_all_articles_pagination(self, token=''):
+        """
+        Test can get all articles has a paginated response
+        """
+
+        if not token:
+            token = self.login_user_and_get_token(self.base_data.user_data)
+
+        letters = string.ascii_letters
+        i = 0
+        for i in range(20):
+            self.client.post('/api/articles/',
+                             self.base_data.article_data,
+                             HTTP_AUTHORIZATION='Bearer ' +
+                             token,
+                             format='json')
+            self.base_data.article_data.update({'title': ''.join(random.choice(letters))})
+            self.base_data.article_data.update({'body': ''.join(random.choice(letters))})
+            i = i+1
+
+        response = self.client.get('/api/articles/')
+
+        self.assertEqual(response.status_code,
+                         status.HTTP_200_OK)
+
+        response = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(len(response['results']), 9)
+        self.assertTrue(response['count'], 19)
 
     def test_can_get_one_article(self, token=''):
         """


### PR DESCRIPTION
### What does this PR do?
Implements pagination on the get all articles endpoint

### Description of Task(s) to be completed?

- Ensure a count of ten in a single page
- Write unit tests for the functionality

### What are the relevant PT stories?
[#165305275](https://www.pivotaltracker.com/story/show/165305275)

### How should this be manually tested?

- [x] **Clone this repository on local machine and CD into project folder**

`$ git clone git@github.com:andela/ah-the-jedi-backend.git`

`$ cd ah-the-jedi-backend`

- [x] **Check out to the PR's branch**

`$ git checkout ft-article-pagination-165305275`

- [x] **Create and activate virtual environment**

`$ python3 -m venv venv`

`$ source .venv/bin/activate`

- [x] **Install app dependencies from requirements.txt**

`$ pip install -r api/requirements.txt`

- [x] **Make migrations and run the server**

`$ python manage.py makemigrations`

`$ python manage.py migrate`

`$ python manage.py runserver`



**Use postman to test the endpoints**



- [x] **Signup and activate user**

           POST <your-localhost>/api/users/

           Creates a user profile on successful signup


- [x] **Login user**

       POST <your-localhost>/api/login/ 

       Use the token provided after login for authorization 

- [x] **Get all articles**

      `GET`  `<you-local-host>/api/articles/`

**Screenshots**
*Get all articles page 1*
<img width="1138" alt="Screenshot 2019-05-06 at 11 37 09" src="https://user-images.githubusercontent.com/45317755/57214727-8627c480-6ff3-11e9-859c-069510448e75.png">

*Get all articles page 2*
<img width="1140" alt="Screenshot 2019-05-06 at 11 38 06" src="https://user-images.githubusercontent.com/45317755/57214739-9049c300-6ff3-11e9-8d92-82929ee3b36a.png">










