### PR TITLE
#165305273 List user profiles functionality

### DIFF
--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
 from .views import (
-    ProfileRetreiveUpdateAPIView
+    ProfileRetreiveUpdateAPIView, ListProfilesView
 )
 
 urlpatterns = [
     path("profiles/<username>",
          ProfileRetreiveUpdateAPIView.as_view()),
+    path("profiles/", ListProfilesView.as_view())
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,6 +1,6 @@
 import json
 from django.http.response import Http404
-from rest_framework import status
+from rest_framework import status, permissions
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.exceptions import (ParseError, NotFound)
 from rest_framework.response import Response
@@ -87,3 +87,14 @@ class ProfileRetreiveUpdateAPIView(RetrieveUpdateAPIView):
         serializer.save()
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ListProfilesView(APIView):
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = ProfileSerializer
+
+    def get(self, request):
+        queryset = UserProfile.objects.all()
+        serializer = ProfileSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/authors/tests/data/base_test.py
+++ b/authors/tests/data/base_test.py
@@ -120,6 +120,20 @@ class BaseTest(TestCase):
             format="json"
         )
 
+    def get_all_profiles(self, token):
+        """
+        This method accesses the get all
+        profiles endpoint which takes a
+        token since the route is authenticated
+        """
+
+        return self.client.get(
+            "/api/profiles/",
+            HTTP_AUTHORIZATION='Bearer ' +
+            token,
+            format="json"
+        )
+
     def generate_image(self):
         """
         This method 'generate_image'

--- a/authors/tests/data/test_profile.py
+++ b/authors/tests/data/test_profile.py
@@ -143,3 +143,20 @@ class ProfileTest(BaseTest):
         self.assertTrue(
             "Ensure that the file is an image" in
             updated_profile.data["errors"])
+
+    def test_authenticated_user_gets_all_profiles(self):
+        """
+        Test that shows an authenticated user can get all listed user profiles.
+        """
+        profiles = self.get_all_profiles(token=self.user_token)
+
+        self.assertEqual(profiles.status_code, 200)
+        self.assertTrue(profiles.data)
+
+    def test_unauthenticated_user_cannot_get_all_profiles(self):
+        """
+        Test that shows an unauthenticated user cannot get all listed user profiles.
+        """
+        profiles = self.get_all_profiles(token='')
+
+        self.assertEqual(profiles.status_code, 401)


### PR DESCRIPTION
### What does this PR do?
- Adds the list user profiles functionality

### Description of the task to be completed?
- Ensure a user is authenticated in order to view profiles
- Ensure unauthenticated users cannot get all profiles
- Write unit tests for the functionality

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/andela/ah-the-jedi-backend.git


- [x] **Switch to testing branch**

       $ git checkout ft-list-users-165305273

- [x] **Switch to the parent directory**

       $ cd ah-the-jedi-backend/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver


- [x] **Signup and activate user**

           POST <your-localhost>/api/users/

           Creates a user profile on successful signup

- [x] **Login user**

       POST <your-localhost>/api/login/ 


       Use the token provided after login for Authorization and the endpoint
  
- [x] **Get all profiles**

      GET <your-localhost>/api/profiles/


### Testing

      $ python api/manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#165305273](https://www.pivotaltracker.com/story/show/165305273)


### Screenshots
### Successful get all profiles
<img width="1143" alt="Screenshot 2019-05-07 at 13 19 27" src="https://user-images.githubusercontent.com/45317755/57292613-c7d76e80-70ca-11e9-9ee5-e49dff07be9e.png">









