### PR TITLE
#165853330 Redirect Heroku Application to swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Authors Haven - A Social platform for the creative at heart.
 =======
 
-Authors Haven Documentation is availabe [Here](https://ah-the-jedi-backend-staging.herokuapp.com/api/)
+Authors Haven Documentation is availabe [Here](https://ah-the-jedi-backend-staging.herokuapp.com/)
 
 
 ## Vision

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -318,6 +318,8 @@ class CommentView(viewsets.ModelViewSet):
 
 class LikeView(GenericAPIView):
     """The like view for articles"""
+    permission_classes = [IsAuthenticated]
+    serializer_class = ArticleSerializer
 
     def post(self, request, *args, **kwargs):
         slug = self.kwargs.get('slug')
@@ -350,6 +352,8 @@ class LikeView(GenericAPIView):
 
 class DisLikeView(GenericAPIView):
     """The like view for articles"""
+    permission_classes = [IsAuthenticated]
+    serializer_class = ArticleSerializer
 
     def post(self, request, *args, **kwargs):
         slug = self.kwargs.get('slug')

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,13 +1,10 @@
-from rest_framework_swagger.views import get_swagger_view
 from django.urls import path
-from django.conf.urls import url
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
     ActivationView, ResetPasswordView, ResetPasswordAPIView, SocialLoginView
 )
 
-swagger_view = get_swagger_view(title='The Jedi Authors Haven API')
 
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view()),
@@ -16,6 +13,5 @@ urlpatterns = [
     path('users/activate/', ActivationView.as_view()),
     path('users/reset_password/', ResetPasswordView.as_view()),
     path('users/reset_password_confirm/', ResetPasswordAPIView.as_view()),
-    url(r'^$', swagger_view),
     path('users/social/login/', SocialLoginView.as_view())
 ]

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -96,6 +96,16 @@ class LoginAPIView(GenericAPIView):
 
 
 class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
+    """
+    get:
+    Get logged in user user.
+
+    patch:
+    Edit user.
+
+    put:
+    Edit user.
+    """
     permission_classes = (IsAuthenticated,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = UserSerializer
@@ -215,7 +225,7 @@ class ResetPasswordView(GenericAPIView):
 
 
 class ResetPasswordAPIView(GenericAPIView):
-    """Patch: Reset Password """
+    """Reset password"""
     renderer_classes = (UserJSONRenderer,)
     serializer_class = UidAndTokenSerializer
     permission_classes = [permissions.AllowAny]
@@ -282,18 +292,19 @@ class SocialLoginView(generics.GenericAPIView):
                 token = {
                     'oauth_token': serializer.initial_data.get('access_token'),
                     'oauth_token_secret': serializer.initial_data.get('access_token_secret')
-                } # pragma: no cover
-                user = backend.do_auth(token)# pragma: no cover
-                url = 'https://api.twitter.com/1.1/account/verify_credentials.json' # pragma: no cover
+                }  # pragma: no cover
+                user = backend.do_auth(token)  # pragma: no cover
+                url = 'https://api.twitter.com/1.1/account/verify_credentials.json'  # pragma: no cover
                 twitter = OAuth1Session(client_key=os.environ.get('SOCIAL_AUTH_TWITTER_KEY'),
                                         client_secret=os.environ.get(
                                             'SOCIAL_AUTH_TWITTER_SECRET'),
                                         resource_owner_key=serializer.initial_data.get(
                                             'access_token'),
                                         resource_owner_secret=serializer.initial_data.get('access_token_secret'
-                                                                                          ))# pragma: no cover
-                response = twitter.get(f'{url}?include_email=true') # pragma: no cover
-                id_info = json.loads(response.text) # pragma: no cover
+                                                                                          ))  # pragma: no cover
+                response = twitter.get(
+                    f'{url}?include_email=true')  # pragma: no cover
+                id_info = json.loads(response.text)  # pragma: no cover
                 if user and user.is_active:
                     token = handle_token(user)
                     response = {

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -90,6 +90,7 @@ class ProfileRetreiveUpdateAPIView(RetrieveUpdateAPIView):
 
 
 class ListProfilesView(APIView):
+    """List users profiles"""
 
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = ProfileSerializer

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -13,24 +13,28 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
 from django.urls import path
+from rest_framework_swagger.views import get_swagger_view
 
 
 articles_urls = include('authors.apps.articles.urls')
 authentication_urls = include('authors.apps.authentication.urls')
 
+swagger_view = get_swagger_view(title='The Jedi Authors Haven API')
+
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^api/', include(('authors.apps.authentication.urls',
-                           'authentication'), namespace='authentication')),
-    url(r'^api/', include(('authors.apps.profiles.urls',
-                           'profiles'), namespace='profiles')),
+    path('admin/', admin.site.urls),
+    path('api/', include(('authors.apps.authentication.urls',
+                          'authentication'), namespace='authentication')),
+    path('api/', include(('authors.apps.profiles.urls',
+                          'profiles'), namespace='profiles')),
     path('api/', authentication_urls),
     path('api/', articles_urls),
     path('api/users/social/', include('rest_framework_social_oauth2.urls')),
-    url(r'^api/', include(('authors.apps.follows.urls',
-                           'follows'), namespace='follows')),
-    path('api/', include('authors.apps.ratings.urls'))
+    path('api/', include(('authors.apps.follows.urls',
+                          'follows'), namespace='follows')),
+    path('api/', include('authors.apps.ratings.urls')),
+    path('', swagger_view, name="root_url"),
 ]


### PR DESCRIPTION
#### What does this PR do?
- Changes the documentation url to exclude `/api/` in the url
#### Description of Task to be completed?
- Change the documentation url to exclude `/api/` in the url
- change all instances of python `url` and use `path`

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/andela/ah-the-jedi-backend.git


- [x] **Switch to testing branch**

       $ git checkout ft-like-dislike-articles-165305269

- [x] **Switch to the parent directory**

       $ cd ah-the-jedi-backend/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver

### Go to the URL to view the documentation
```<your-localhost>/```

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#165853330](https://www.pivotaltracker.com/story/show/165853330)

#### Screenshot
### Swagger view when a user is not authenticated
<img width="1440" alt="Screenshot 2019-05-08 at 17 34 35" src="https://user-images.githubusercontent.com/19903559/57383571-b6b85b80-71b7-11e9-86d3-ea02f48ab779.png">

### Swagger view when a user is authenticated
<img width="1440" alt="Screenshot 2019-05-08 at 17 33 52" src="https://user-images.githubusercontent.com/19903559/57383582-bc15a600-71b7-11e9-89c2-e40c730e8622.png">

#### Questions:
Any feedback?
