### PR TITLE
#165962471 Users receive notifications

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,9 @@ omit =
     authors/apps/ratings/apps.py
     authors/apps/notifications/apps.py
     authors/apps/highlights/apps.py
+    authors/apps/notifications/utils.py 
+    authors/apps/profiles/utils.py
+    
 
 [report]
 exclude_lines =

--- a/authors/apps/notifications/actions.py
+++ b/authors/apps/notifications/actions.py
@@ -3,11 +3,15 @@ from fluent_comments.models import FluentComment
 
 from ..articles import models
 from ..authentication.models import User
+from ..follows.models import UserFollow
 from .utils import (create_comment_notification,
-                    create_post_notification, create_subscriptions)
+                    create_post_notification, create_subscriptions,
+                    create_follow_notification)
 
 
 post_save.connect(create_subscriptions, sender=User)
+
+post_save.connect(create_follow_notification, sender=UserFollow)
 
 post_save.connect(create_post_notification, sender=models.ArticleModel)
 

--- a/authors/apps/notifications/models.py
+++ b/authors/apps/notifications/models.py
@@ -20,6 +20,9 @@ class Notifications(models.Model):
 
     createdAt = models.DateTimeField(auto_now_add=True, editable=False)
 
+    class Meta:
+        ordering = ["-createdAt"]
+
     def __str__(self):
 
         return self.message  # pragma: no cover

--- a/authors/tests/data/test_notifications.py
+++ b/authors/tests/data/test_notifications.py
@@ -50,7 +50,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         follow = self.follow_user(self.control_username, self.user_token)
 
@@ -64,7 +64,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue(notification.data["count"] == 1)
+        self.assertTrue(notification.data["count"] == 2)
 
     def test_creates_in_app_notification_if_comment(self):
         """
@@ -76,7 +76,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         article = self.create_article(token=self.control_token)
 
@@ -105,6 +105,18 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
+        self.assertTrue(notification.data["count"] == 2)
+
+    def test_creates_in_app_notification_if_follow(self):
+        """
+        Test creates in_app notification if a user follows
+        another user
+        """
+
+        notification = self.fetch_all_notifications(token=self.user_token)
+
+        self.assertEqual(notification.status_code, status.HTTP_200_OK)
+
         self.assertTrue(notification.data["count"] == 1)
 
     def test_fetches_unread_notifications(self):
@@ -116,7 +128,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         follow = self.follow_user(self.control_username, self.user_token)
 
@@ -130,7 +142,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue(notification.data["count"] == 1)
+        self.assertTrue(notification.data["count"] == 2)
 
     def test_reads_and_fetches_read_notifications(self):
         """
@@ -142,7 +154,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         follow = self.follow_user(self.control_username, self.user_token)
 
@@ -153,6 +165,8 @@ class NotificationTest(BaseTest):
         self.assertEqual(article.status_code, status.HTTP_201_CREATED)
 
         notification = self.fetch_all_notifications(token=self.user_token)
+
+        self.assertTrue(notification.data["count"] == 2)
 
         id = notification.data["notifications"][0].get("id", None)
 
@@ -170,7 +184,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
     def test_fetches_subscriptions(self):
         """
@@ -204,7 +218,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         follow = self.follow_user(self.control_username, self.user_token)
 
@@ -218,7 +232,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
     def test_raises_error_if_reading_articles_not_owned(self):
         """
@@ -230,7 +244,7 @@ class NotificationTest(BaseTest):
 
         self.assertEqual(notification.status_code, status.HTTP_200_OK)
 
-        self.assertTrue("do not have" in notification.data["notifications"])
+        self.assertTrue(notification.data["count"] == 1)
 
         follow = self.follow_user(self.control_username, self.user_token)
 


### PR DESCRIPTION
### What does this PR do?

Adds implementation for sending email and in-app notifications

### Description of the task to be completed?

- Add implementation for sending in-app and email notifications when followed users create new articles to article owner.
- Add implementation for sending in-app and email notifications when a user follows another.
- Add tests for notifications

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/andela/ah-the-jedi-backend.git


- [x] **Switch to testing branch**

       $ git checkout ft-user-receive-notifications-165962471

- [x] **Switch to the ah-the-jedi-backend directory**

       $ cd ah-the-jedi-backend/

 
- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r requirements.txt


- [x] **Run the database migrations**

       $ python manage.py migrate


### Running the application

      $ python manage.py runserver


- [x] **Signup and activate two users (user one & user two)**

           POST <your-localhost>/api/users/

           Creates a user profile on successful signup


           POST <your-localhost>/api/users/activate/?uid=<uid>&token=<token>

           Activates an account


- [x] **Login user (both users)**

       POST <your-localhost>/api/login/ 

       Use the token provided after login for authorization 

  
- [x] **Follow user one as user two**


      POST <your-localhost>/api/profiles/<user-two-username>/follow

      Authentication required


- [x] **Fetch notifications (as user one)**


      GET <your-localhost>/api/notifications/all

      Authentication required

     Check your email for notification


- [x] **Create an article (as user two)**


      POST <your-localhost>/api/articles/

      Authentication required

- [x] **Fetch notifications (as user one)**


      GET <your-localhost>/api/notifications/all

      Authentication required

     Check your email for notification

- [x] **Favorite the article (as user one)**


      POST <your-localhost>/api/articles/<slug>/favorite/

      Authentication required

- [x] **Comment on the article (as user two)**


      POST <your-localhost>/api/articles/<slug>/comments/

      Authentication required

- [x] **Fetch notifications (as user one)**


      GET <your-localhost>/api/notifications/all

      Authentication required

     Check your email for notification


- [x] **Fetch all subscriptions**


      GET <your-localhost>/api/notifications/subscriptions

      Authentication required


- [x] **Mark notifications as read**


      PUT <your-localhost>/api/notifications/read/<id>

      Authentication required

- [x] **Fetch all notifications (as user one and user two)**


      PUT <your-localhost>/api/notifications/all

      Authentication required

     

### Testing

      $ python manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#165962471](https://www.pivotaltracker.com/story/show/165962471)


### Screenshots

***In-app notifications***
<img width="1088" alt="Screenshot 2019-05-13 at 22 02 13" src="https://user-images.githubusercontent.com/33033576/57696914-acd0a580-765a-11e9-931c-7393f85efe75.png">

<img width="1113" alt="Screenshot 2019-05-14 at 15 23 49" src="https://user-images.githubusercontent.com/33033576/57697598-519fb280-765c-11e9-8427-eadb103e40d2.png">


***Email Notifications***
<img width="1121" alt="Screenshot 2019-05-14 at 15 20 55" src="https://user-images.githubusercontent.com/33033576/57697453-ea81fe00-765b-11e9-9a27-66c8423030fc.png">

<img width="1052" alt="Screenshot 2019-05-14 at 15 14 28" src="https://user-images.githubusercontent.com/33033576/57697514-17361580-765c-11e9-83df-0612c9c7b657.png">


















