### PR TITLE
#166065564 Fix User Notifications

### DIFF
--- a/authors/apps/notifications/utils.py
+++ b/authors/apps/notifications/utils.py
@@ -227,8 +227,13 @@ def make_notifications(user, article, slug, obj, comment=False):
 
         if user.username != article.author.username:
 
-            mails.append(
-                fetch_user(username=article.author.username).email)
+            if article.author.email not in app_exclude:
+
+                save_notifications(article.author.username, message, url)
+
+            if article.author.email not in mail_exlude:
+                mails.append(
+                    fetch_user(username=article.author.username).email)
 
     else:
 


### PR DESCRIPTION
### What does this PR do?

Adds implementation for saving in-app notifications for the article authors.

### Description of the task to be completed?

- Add implementation for saving in-app to the article authors when users comment on the article.
- Add tests for these notifications.

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/andela/ah-the-jedi-backend.git


- [x] **Switch to testing branch**

       $ git checkout bg-fix-user-notifications-166065564

- [x] **Switch to the ah-the-jedi-backend directory**

       $ cd ah-the-jedi-backend/

 
- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r requirements.txt


- [x] **Run the database migrations**

       $ python manage.py migrate


### Running the application

      $ python manage.py runserver


- [x] **Signup and activate two users (user one & user two)**

           POST <your-localhost>/api/users/

           Creates a user profile on successful signup


           POST <your-localhost>/api/users/activate/?uid=<uid>&token=<token>

           Activates an account


- [x] **Login user (both users)**

       POST <your-localhost>/api/login/ 

       Use the token provided after login for authorization 


- [x] **Create an article (as user two)**


      POST <your-localhost>/api/articles/

      Authentication required


- [x] **Comment on the article (as user one)**


      POST <your-localhost>/api/articles/<slug>/comments/

      Authentication required

- [x] **Fetch notifications (as user two)**


      GET <your-localhost>/api/notifications/all

      Authentication required

     Check your email for notification



### Testing

      $ python manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#166065564](https://www.pivotaltracker.com/story/show/166065564)


### Screenshots

***In-app notifications***

<img width="1113" alt="Screenshot 2019-05-14 at 15 23 49" src="https://user-images.githubusercontent.com/33033576/57697598-519fb280-765c-11e9-8427-eadb103e40d2.png">


***Email Notifications***

<img width="1052" alt="Screenshot 2019-05-14 at 15 14 28" src="https://user-images.githubusercontent.com/33033576/57697514-17361580-765c-11e9-83df-0612c9c7b657.png">


















