### PR TITLE
#166083772 Fix status codes returned when updating a comment.

### DIFF
--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -188,7 +188,7 @@ def get_comment_queryset(request, slug):
         response = {
             'error': 'Article with slug {} not found'.format(slug)
         }
-        raise ValidationError(response)
+        raise NotFound(response)
 
     comment_id = request.GET.get('id')
 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -318,13 +318,13 @@ class CommentView(viewsets.ModelViewSet):
                 response = {
                     'error': 'You cannot update a comment you do not own.'
                 }
-                return Response(data=response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(data=response, status=status.HTTP_401_UNAUTHORIZED)
 
             if request.data['comment'] == old_comment:
                 response = {
                     'error': 'This is the current comment'
                 }
-                return Response(data=response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(data=response, status=status.HTTP_409_CONFLICT)
 
             comment, created = CommentHistoryModel.objects.get_or_create(
                 updated_comment=old_comment, comment=queryset)

--- a/authors/tests/data/test_comments_history.py
+++ b/authors/tests/data/test_comments_history.py
@@ -76,7 +76,7 @@ class CommentHistoryTestCase(BaseTest):
             self.token, format='json')
 
         self.assertEqual(update_comment.status_code,
-                         status.HTTP_400_BAD_REQUEST)
+                         status.HTTP_409_CONFLICT)
         self.assertEqual(
             update_comment.data['error'], 'This is the current comment')
 
@@ -99,7 +99,7 @@ class CommentHistoryTestCase(BaseTest):
             self.token, format='json')
 
         self.assertEqual(update_comment.status_code,
-                         status.HTTP_400_BAD_REQUEST)
+                         status.HTTP_404_NOT_FOUND)
 
     def test_update_comment_without_comment_id(self):
         """
@@ -162,7 +162,7 @@ class CommentHistoryTestCase(BaseTest):
             self.token2, format='json')
 
         self.assertEqual(update_comment.status_code,
-                         status.HTTP_400_BAD_REQUEST)
+                         status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(
             update_comment.data['error'],
             'You cannot update a comment you do not own.')


### PR DESCRIPTION
#### What does this PR do?
Fixes the status codes returned when updating a comment.
#### Description of Task to be completed?
- Fix status code returned to unauthorized/unallowed when a user tries to update a comment they do not own.
- Fix status code returned to not found when a user tries to update comment with an unexisting slug.
- Fix status code returned to conflict when a user tries to update comment with the same existing comment data.
#### How should this be manually tested?
1. Clone this repo.
   `$ git clone https://github.com/andela/ah-the-jedi-backend.git`
2. Fetch all origin to get all branches
   `$ git fetch origin`
3. Checkout to `bg-fix-status-codes-166083772` branch.
   `$ git checkout bg-fix-status-codes-166083772`
4. Activate `virtualenv`
    `$ virtualenv -p python .venv`
    `$ source .venv/bin/activate`
5. Install requirements
   `$ pip install -r requirements.txt`
6. Start server
   `$ python manage.py runserver`
7. Test the endpoint on postman in the following steps:
- Ensure the user is authenticated.
- Update a comment - `PUT /api/articles/<slug>/comments/?id=`
#### What are the relevant pivotal tracker stories?
[#166083772](https://www.pivotaltracker.com/story/show/166083772)
#### Screenshots (if appropriate)
Update a comment with the same existing comment data
<img width="1110" alt="Screenshot 2019-05-20 at 12 27 45" src="https://user-images.githubusercontent.com/17095461/58011454-f1e15580-7afa-11e9-9b34-e7aa03eb3b99.png">

Update a comment with unexisting slug
<img width="1111" alt="Screenshot 2019-05-20 at 12 29 05" src="https://user-images.githubusercontent.com/17095461/58011461-f6a60980-7afa-11e9-9c87-81370b6de01e.png">

Update a comment you do not own.
<img width="1111" alt="Screenshot 2019-05-20 at 12 32 57" src="https://user-images.githubusercontent.com/17095461/58011683-792ec900-7afb-11e9-9bf3-df29b73650b1.png">
