### PR TITLE
#165962589 Return user rating in article details

### DIFF
--- a/authors/tests/data/test_rating.py
+++ b/authors/tests/data/test_rating.py
@@ -127,3 +127,29 @@ class RatingsTest(BaseTest):
         res = json.loads(response.content.decode('utf-8'))
         self.assertTrue('average_rating' in res['data'])
         self.assertIsInstance(res['data']['average_rating'], float)
+
+    def test_user_rating_in_article_details(self):
+        """
+        Test to ensure that the specific user rating is returned
+        when a user gets an article and that it is a float
+        """
+        article = self.create_article()
+        slug = article.data['data']['slug']
+
+        self.client.post(
+            "/api/articles/{}/rate/".format(slug),
+            self.base_data.rating_data,
+            format='json',
+            HTTP_AUTHORIZATION='Bearer ' + self.control_token
+        )
+
+        response = self.client.get('/api/articles/{}/'.format(slug),
+                                   HTTP_AUTHORIZATION='Bearer ' +
+                                   self.control_token)
+
+        self.assertEqual(response.status_code,
+                         status.HTTP_200_OK)
+
+        res = json.loads(response.content.decode('utf-8'))
+        self.assertTrue('user_rating' in res['data'])
+        self.assertEqual(res['data']['user_rating'], 5)

--- a/authors/tests/data/test_read_stats.py
+++ b/authors/tests/data/test_read_stats.py
@@ -6,7 +6,7 @@ from .base_test import BaseTest
 from .data import Data
 
 
-class HighlightArticleTestcase(BaseTest):
+class ReadingStatsTestcase(BaseTest):
     """
     This class defines the test suite for like and dislike
     cases.


### PR DESCRIPTION
### What does this PR do?
Implements functionality to return user rating when getting an article

### Description of Task(s) to be completed?
- ensure that the specific rating of the logged in user is returned in article details/ data

### How should this be manually tested?

Clone this repository on local machine and CD into project folder
`$ git clone git@github.com:andela/ah-the-jedi-backend.git`
`$ cd ah-the-jedi-backend`

Check out to the PR's branch
`$ git checkout bg-user-rating-165962589`

Create and activate virtual environment
`$ python3 -m venv venv`
`$ source .venv/bin/activate`

Install app dependencies from requirements.txt
`$ pip install -r api/requirements.txt`

Make migrations and run the server
`$ python manage.py makemigrations`
`$ python manage.py migrate`
`$ python manage.py runserver`

**Use postman to test the endpoints**

- [x] **Signup and activate user**

           POST <your-localhost>/api/users/


- [x] **Login user**

       POST <your-localhost>/api/login/ 

       Use the token provided after login for authorization 

      
- [x] **rate an article**

      `POST`  `<you-local-host>/api/articles/<slug>/rate`

- [x] **get the rated article and include authentication details**

      `GET`  `<you-local-host>/api/articles/<slug>/`

### What are the relevant PT stories?
[#165962589](https://www.pivotaltracker.com/story/show/165962589)

### Screenshots
![image](https://user-images.githubusercontent.com/11965186/58170400-01e46b00-7c9c-11e9-8f3d-4d06dbe75483.png)
