### PR TITLE
#166348255 Fix reset password confirm url

### DIFF
--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -211,7 +211,7 @@
                         <tr>
                           <td align="center">
                             <div>
-                              <a id="Link" href="{{domain}}/api/users/reset_password_confirm?uid={{uid}}&token={{token}}" class="button button--blue">Change Password</a>
+                              <a id="Link" href="{{domain}}/password_confirm?uid={{uid}}&token={{token}}" class="button button--blue">Change Password</a>
                             </div>
                           </td>
                         </tr>
@@ -227,7 +227,7 @@
                               and paste the URL below into your web browser.
                             </p>
                             <p class="sub">
-                              <p class="sub"><a href="{{action_url}}">{{domain}}/api/users/reset_password_confirm?uid={{uid}}&token={{token}}</a></p>
+                              <p class="sub"><a href="{{action_url}}">{{domain}}/password_confirm?uid={{uid}}&token={{token}}</a></p>
                             </p>
                           </td>
                         </tr>


### PR DESCRIPTION
#### What does this PR do?
- Fixes the reset password confirm url.
#### Description of Task to be completed?
- Ensure the reset password confirm URL sent to a user's email redirects to the User interface with the new password field.

### How should you manually test this?

- [x] **Clone the repository**
        $ git clone https://github.com/andela/ah-the-jedi-backend.git

- [x] **Switch to testing branch**
       $ git checkout bg-fix-resetPassword-url-166348255

- [x] **Create and activate the virtual environment**
      $  virtualenv -p python .venv
      $ source .venv/bin/activate

- [x] **Install project dependencies**
       $ pip install -r api/requirements.txt

- [x] **Run the database migrations**
       $ python api/manage.py migrate

### Running the application
      $ python manage.py runserver

- [x] **Reset password**
      GET `/api/users/reset_password/`

- [x] **Go to your email and click on the `Change password` button**

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#166348255](https://www.pivotaltracker.com/story/show/166348255)
#### Screenshots
Change password button from the email alongside the url
<img width="622" alt="Screenshot 2019-05-30 at 10 39 23" src="https://user-images.githubusercontent.com/17095461/58616851-5d7bad80-82c7-11e9-9431-9369736f413f.png">

The url redirects to the User Interface.
<img width="995" alt="Screenshot 2019-05-30 at 10 39 38" src="https://user-images.githubusercontent.com/17095461/58616858-62d8f800-82c7-11e9-9890-27b216e8a89e.png">
