### PR TITLE
#166785601 Fix admin user should be able to delete any article

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -175,7 +175,7 @@ class ArticleView(viewsets.ModelViewSet):
         try:
             article = ArticleModel.objects.filter(slug=slug)[0]
 
-            if not article.author.id == request.user.id:
+            if not (article.author.id == request.user.id or request.user.is_superuser):
                 return Response({'status': 403, 'error': "You cannot delete an article you do not own"}, status=403)
 
             self.perform_destroy(article)

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -127,8 +127,10 @@ class LoginAPIView(GenericAPIView):
         serializer.is_valid(raise_exception=True)
         user_data = User.objects.get(email=user['email'])
         token = handle_token(user_data)
+        isAdmin = user_data.is_superuser
         res = serializer.data
         res['token'] = token
+        res['isAdmin'] = isAdmin
 
         return Response(res, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
#### What does this PR do?
- Implement ability for admin user to delete any article
#### Description of Task to be completed?
- Ensure an authenticated Admin user should be able to delete any article

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/andela/ah-the-jedi-backend.git


- [x] **Switch to testing branch**

       $ git checkout bg-fix-admin-delete-166785601

- [x] **Switch to the parent directory**

       $ cd ah-the-jedi-backend/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver

- [x] **Delete article**


      DELETE <your-localhost>/api/articles/<slug>/

      ADMIN Authentication required

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#166785601](https://www.pivotaltracker.com/story/show/166785601)

#### Screenshot
### Delete an article
![image](https://user-images.githubusercontent.com/19903559/59744292-f07e8680-927a-11e9-9fdb-62e9598d8bf4.png)


